### PR TITLE
[bugfix] createShadowRoot is on the prototype.

### DIFF
--- a/ext/shadowcrypt.js
+++ b/ext/shadowcrypt.js
@@ -110,7 +110,7 @@ Content.within = function () {
 		gateMethodProto(win.Selection.prototype, 'removeAllRanges', notInContentEditable.bind(null, win));
 		gateMethodProto(win.Selection.prototype, 'addRange', notInContentEditable.bind(null, win));
 		// caveat: breaks shadow dom for content
-		delete Element.createShadowRoot;
+		delete Element.prototype.createShadowRoot;
 		shimSelectorsAPI(win);
 	}
 


### PR DESCRIPTION
When shadowcrypt is refactored to support editing getter/setter properties on prototypes, code should also be updated to delete the correct attribute. If page code can create shadow roots, event retargeting can allow bypassing checks in the content script.
